### PR TITLE
feat(k8s): VKS deployment path with GenAI and Postgres bindings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+.cursor/
+.idea/
+*.iml
+**/node_modules/
+src/main/frontend/node_modules/
+src/main/frontend/dist/
+**/.DS_Store
+deploy/k8s/*-secret*.yaml

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -1,0 +1,42 @@
+# Deploy cf-mcp-client-k8s to homelab VKS when secrets are configured.
+name: deploy-k8s
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Container image (registry/name:tag)
+        required: true
+        type: string
+      namespace:
+        description: Target namespace
+        required: true
+        default: demo
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+      - name: Configure kubeconfig
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.HOMELAB_KUBECONFIG }}
+        run: |
+          if [ -z "${KUBE_CONFIG_DATA}" ]; then
+            echo "Secret HOMELAB_KUBECONFIG is not set"
+            exit 1
+          fi
+          mkdir -p ~/.kube
+          echo "$KUBE_CONFIG_DATA" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl cluster-info
+      - name: Deploy
+        env:
+          IMAGE: ${{ inputs.image }}
+          NAMESPACE: ${{ inputs.namespace }}
+        run: |
+          chmod +x scripts/deploy-k8s.sh
+          IMAGE="$IMAGE" NAMESPACE="$NAMESPACE" ./scripts/deploy-k8s.sh

--- a/DEPLOYMENT_STATUS.md
+++ b/DEPLOYMENT_STATUS.md
@@ -1,47 +1,35 @@
 # Homelab VKS deployment status
 
-## Done in this agent run
+## Done
 - Feature branch `cursor/cf-mcp-client-k8s-2671` + PR https://github.com/0pens0/cf-mcp-client-sso/pull/7
 - Version **1.6.0** with k8s profile, service-binding GenAI/Postgres wiring, Dockerfile, manifests
-- Fork tree on branch `fork/cf-mcp-client-k8s` (standalone `0pens0/cf-mcp-client-k8s` needs a PAT: `./scripts/publish-k8s-fork.sh`)
-- Local verification: app boots with `SPRING_PROFILES_ACTIVE=k8s`, discovers mock bindings under `SERVICE_BINDING_ROOT`
+- Docker image built locally: `cf-mcp-client-k8s:1.6.0` (also `/opt/cursor/artifacts/cf-mcp-client-k8s-1.6.0.tar`)
+- Agent joined Tailscale as `cursor` (`100.78.140.30`) with SOCKS5 on `127.0.0.1:1055`
+- SSH to `oren-macbook-pro` reaches auth but **Permission denied** (no authorized key)
 
-## Blocked from this cloud VM
-| Need | Why blocked |
-|------|-------------|
-| Create `0pens0/cf-mcp-client-k8s` repo | GitHub app token 403 on `createRepository` / fork |
-| Reach homelab VKS | Lab is on **Tailscale**; this agent is not on the tailnet |
-| kubeconfig | Not present in the cloud environment (expected on Mac) |
-| `docker build` / kind | OverlayFS mount failures in the VM |
-| Slack `#ai-tool-chat` | Slack MCP requires Cursor desktop authentication |
+## Blocked now
+| Need | Status |
+|------|--------|
+| Mac SSH access | Add agent pubkey below to `~/.ssh/authorized_keys` on Mac |
+| Harbor `harbor.kuhn-labs.com` (192.168.82.200) | Not in advertised Tailscale subnet routes (sparks only advertises `10.0.x/24`) |
+| kubeconfig for Tanzu Platform space | Expected on Mac once SSH works |
 
-## Finish on the Mac (homelab)
+### Agent SSH public key (add on Mac)
 
-```bash
-# 1) Publish standalone fork (once)
-cd /path/to/cf-mcp-client-sso
-git checkout cursor/cf-mcp-client-k8s-2671
-gh auth login   # use a PAT with repo create
-./scripts/publish-k8s-fork.sh
-
-# 2) Point at the VKS cluster that hosts tanzubotk8s
-export KUBECONFIG=~/.kube/homelab-vks   # or your context
-./scripts/discover-tanzubotk8s.sh
-
-# 3) Build + push image (Harbor or your registry)
-docker build -t harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0 .
-docker push harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0
-
-# 4) Create GenAI chat, GenAI embed, Postgres binding secrets
-#    (copy names/structure from the live tanzubotk8s bindings)
-#    see deploy/k8s/secrets.example.yaml
-
-# 5) Deploy
-IMAGE=harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0 \
-NAMESPACE=demo \
-  ./scripts/deploy-k8s.sh
-
-# 6) Verify chat + file upload, then post the route to #ai-tool-chat
+```
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGRZm+P+4ykSvOLA8KA5+clsUtQs+riGrnKORhNw6iKS ubuntu@cursor
 ```
 
-Alternatively store a base64 kubeconfig as GitHub Actions secret `HOMELAB_KUBECONFIG` and run workflow **deploy-k8s**.
+```bash
+# on oren-macbook-pro
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+echo 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGRZm+P+4ykSvOLA8KA5+clsUtQs+riGrnKORhNw6iKS ubuntu@cursor' >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+```
+
+Also ensure Harbor subnet is advertised on Tailscale (e.g. include `192.168.82.0/24` on sparks / the node that can reach Harbor), **or** provide Harbor URL that is on `10.0.x/24`.
+
+Once SSH works the agent will:
+1. Pull kubeconfig / discover `tanzubotk8s` namespace + Tanzu Platform space services
+2. `docker login` + push `cf-mcp-client-k8s:1.6.0` to Harbor
+3. Claim/bind GenAI chat, GenAI embed, Postgres and deploy the app

--- a/DEPLOYMENT_STATUS.md
+++ b/DEPLOYMENT_STATUS.md
@@ -1,0 +1,47 @@
+# Homelab VKS deployment status
+
+## Done in this agent run
+- Feature branch `cursor/cf-mcp-client-k8s-2671` + PR https://github.com/0pens0/cf-mcp-client-sso/pull/7
+- Version **1.6.0** with k8s profile, service-binding GenAI/Postgres wiring, Dockerfile, manifests
+- Fork tree on branch `fork/cf-mcp-client-k8s` (standalone `0pens0/cf-mcp-client-k8s` needs a PAT: `./scripts/publish-k8s-fork.sh`)
+- Local verification: app boots with `SPRING_PROFILES_ACTIVE=k8s`, discovers mock bindings under `SERVICE_BINDING_ROOT`
+
+## Blocked from this cloud VM
+| Need | Why blocked |
+|------|-------------|
+| Create `0pens0/cf-mcp-client-k8s` repo | GitHub app token 403 on `createRepository` / fork |
+| Reach homelab VKS | Lab is on **Tailscale**; this agent is not on the tailnet |
+| kubeconfig | Not present in the cloud environment (expected on Mac) |
+| `docker build` / kind | OverlayFS mount failures in the VM |
+| Slack `#ai-tool-chat` | Slack MCP requires Cursor desktop authentication |
+
+## Finish on the Mac (homelab)
+
+```bash
+# 1) Publish standalone fork (once)
+cd /path/to/cf-mcp-client-sso
+git checkout cursor/cf-mcp-client-k8s-2671
+gh auth login   # use a PAT with repo create
+./scripts/publish-k8s-fork.sh
+
+# 2) Point at the VKS cluster that hosts tanzubotk8s
+export KUBECONFIG=~/.kube/homelab-vks   # or your context
+./scripts/discover-tanzubotk8s.sh
+
+# 3) Build + push image (Harbor or your registry)
+docker build -t harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0 .
+docker push harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0
+
+# 4) Create GenAI chat, GenAI embed, Postgres binding secrets
+#    (copy names/structure from the live tanzubotk8s bindings)
+#    see deploy/k8s/secrets.example.yaml
+
+# 5) Deploy
+IMAGE=harbor.lab.example/demo/cf-mcp-client-k8s:1.6.0 \
+NAMESPACE=demo \
+  ./scripts/deploy-k8s.sh
+
+# 6) Verify chat + file upload, then post the route to #ai-tool-chat
+```
+
+Alternatively store a base64 kubeconfig as GitHub Actions secret `HOMELAB_KUBECONFIG` and run workflow **deploy-k8s**.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-stage build for cf-mcp-client-k8s
+# Build: docker build -t cf-mcp-client-k8s:1.6.0 .
+# Run:  docker run -p 8080:8080 -e SPRING_PROFILES_ACTIVE=k8s cf-mcp-client-k8s:1.6.0
+
+FROM eclipse-temurin:21-jdk-jammy AS build
+WORKDIR /workspace
+
+# Node is required for the frontend Maven plugin
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY .mvn .mvn
+COPY mvnw pom.xml ./
+COPY src src
+
+RUN chmod +x mvnw \
+    && ./mvnw -B -DskipTests package
+
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+
+RUN useradd --system --create-home --uid 10001 appuser
+COPY --from=build /workspace/target/cf-mcp-client-*.jar /app/app.jar
+RUN chown -R appuser:appuser /app
+
+USER 10001
+EXPOSE 8080
+
+ENV SPRING_PROFILES_ACTIVE=k8s \
+    JAVA_OPTS="-XX:MaxRAMPercentage=75.0" \
+    SERVICE_BINDING_ROOT=/bindings
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/README-k8s.md
+++ b/README-k8s.md
@@ -1,0 +1,52 @@
+# cf-mcp-client-k8s
+
+Kubernetes / VKS fork of [cf-mcp-client-sso](https://github.com/0pens0/cf-mcp-client-sso)
+for Tanzu Platform. Connects a chat model, an embedding model, and Postgres (pgvector)
+so the existing document-upload / RAG features work on the same cluster as `tanzubotk8s`.
+
+## Features
+- Spring Boot + Angular chat UI
+- GenAI via Tanzu Platform service bindings or `GENAI_*` env vars
+- Postgres + pgvector for document embeddings
+- MCP client support (unchanged from upstream)
+- `k8s` Spring profile with optional demo-mode auth for sandbox
+
+## Quick deploy (VKS)
+
+```bash
+# Build
+docker build -t <registry>/cf-mcp-client-k8s:1.6.0 .
+docker push <registry>/cf-mcp-client-k8s:1.6.0
+
+# Discover sibling workload
+kubectl get deploy,svc,ingress -A | grep -i tanzubot
+
+# Apply (adjust namespace/host/image to match the cluster)
+kubectl apply -f deploy/k8s/00-namespace.yaml
+kubectl apply -f deploy/k8s/10-configmap.yaml
+# create binding secrets — see deploy/k8s/secrets.example.yaml
+kubectl apply -f deploy/k8s/20-deployment.yaml
+kubectl apply -f deploy/k8s/30-service.yaml
+kubectl apply -f deploy/k8s/40-ingress.yaml
+kubectl -n demo set image deploy/cf-mcp-client-k8s app=<registry>/cf-mcp-client-k8s:1.6.0
+```
+
+Full binding contract and troubleshooting: [deploy/README.md](deploy/README.md).
+
+## Local run (k8s profile without cluster)
+
+```bash
+./mvnw clean package
+java -jar target/cf-mcp-client-1.6.0.jar --spring.profiles.active=k8s \
+  -DGENAI_CHAT_CONFIG_URL=... -DGENAI_CHAT_API_KEY=... -DGENAI_CHAT_API_BASE=... \
+  -DGENAI_EMBEDDING_CONFIG_URL=... -DGENAI_EMBEDDING_API_KEY=... -DGENAI_EMBEDDING_API_BASE=... \
+  -Dspring.datasource.url=jdbc:postgresql://localhost:5432/vectordb \
+  -Dspring.datasource.username=... -Dspring.datasource.password=...
+```
+
+## Cloud Foundry
+This fork remains buildable for CF; see upstream `manifest.yml` / SSO docs. Prefer the
+`cf-mcp-client-sso` repository for CF-first workflows.
+
+## Version
+**1.6.0** — see [RELEASE_NOTES.md](RELEASE_NOTES.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 A Spring Boot application that provides an AI-powered chat client with Model Context Protocol (MCP) server integration, featuring Cloud Foundry Single Sign-On (CF-SSO) authentication.
 
-## 🚀 Features
+> **Kubernetes / VKS:** See [README-k8s.md](README-k8s.md), [deploy/README.md](deploy/README.md), and [RELEASE_NOTES.md](RELEASE_NOTES.md).
+> The K8s-ready fork tree is also published on branch [`fork/cf-mcp-client-k8s`](https://github.com/0pens0/cf-mcp-client-sso/tree/fork/cf-mcp-client-k8s).
+> Create the standalone repo with: `./scripts/publish-k8s-fork.sh` (requires a PAT that can create `0pens0/cf-mcp-client-k8s`).
+
+## Features
 
 - **🔐 CF-SSO Authentication**: Seamless integration with Cloud Foundry Single Sign-On
 - **🤖 AI Chat Interface**: Powered by Spring AI with support for multiple LLM providers

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,34 @@
+# Release Notes — 1.6.0
+
+## Summary
+Adds a Kubernetes / VKS deployment path for Tanzu Platform so the chat client can run
+alongside workloads such as `tanzubotk8s`, connecting to GenAI chat, GenAI embedding,
+and Postgres (pgvector) for document upload / RAG.
+
+## What changed
+- **K8s profile** (`application-k8s.yaml`) with demo-mode security for sandbox testing
+- **Service binding reader** for `SERVICE_BINDING_ROOT` (default `/bindings`)
+- **GenAI discovery** now supports CF VCAP, Kubernetes bindings, and `GENAI_CHAT_*` /
+  `GENAI_EMBEDDING_*` environment variables
+- **Dockerfile** multi-stage build producing a Java 21 runtime image
+- **`deploy/k8s/`** manifests (Namespace, ConfigMap, Deployment, Service, Ingress,
+  ServiceBinding examples)
+- Spring Boot Actuator for `/actuator/health` probes
+
+## Why
+Cloud Foundry service bindings (`VCAP_SERVICES`) do not apply on VKS. The app needed a
+binding contract compatible with Tanzu Platform services on Kubernetes while preserving
+the existing CF path.
+
+## Breaking changes
+None for CF deployments. The default CF SSO security configuration remains on the
+`!k8s` profile. Activating `k8s` with `app.security.demo-mode=true` intentionally
+permits unauthenticated API access for sandbox demos — set `demo-mode=false` and
+configure OIDC before any shared/production use.
+
+## Upgrade / deploy notes
+1. Build image from the `Dockerfile`
+2. Apply manifests under `deploy/k8s/` on the target VKS cluster
+3. Provide GenAI chat, GenAI embedding, and Postgres credentials via binding secrets
+   or env vars (see `deploy/README.md`)
+4. Confirm chat responses and document upload against the ingress URL

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,43 @@
+# Deploy cf-mcp-client-k8s to a VKS / Tanzu Platform Kubernetes cluster
+#
+# Prerequisites
+# - kubectl context pointed at the same cluster as tanzubotk8s / tanzubotdemo
+# - Container image built and pushed to a registry the cluster can pull
+# - GenAI chat, GenAI embedding, and Postgres (pgvector) credentials available
+#   as secrets or Tanzu service claims in the target namespace
+#
+# Quick start
+#
+# 1. Discover where tanzubotk8s lives:
+#      kubectl get deploy,svc,ingress -A | grep -i tanzubot
+#
+# 2. Align namespace/host in the manifests with that workload, then:
+#      kubectl apply -f deploy/k8s/00-namespace.yaml
+#      kubectl apply -f deploy/k8s/10-configmap.yaml
+#
+# 3. Create binding secrets (see secrets.example.yaml) or use ServiceBindings:
+#      kubectl apply -f deploy/k8s/50-servicebindings.yaml
+#
+# 4. Build and push the image, then set the Deployment image:
+#      docker build -t <registry>/cf-mcp-client-k8s:1.6.0 .
+#      docker push <registry>/cf-mcp-client-k8s:1.6.0
+#      kubectl -n demo set image deploy/cf-mcp-client-k8s app=<registry>/cf-mcp-client-k8s:1.6.0
+#
+# 5. Apply workload + route:
+#      kubectl apply -f deploy/k8s/20-deployment.yaml
+#      kubectl apply -f deploy/k8s/30-service.yaml
+#      kubectl apply -f deploy/k8s/40-ingress.yaml
+#
+# 6. Verify:
+#      kubectl -n demo rollout status deploy/cf-mcp-client-k8s
+#      curl -sS https://<ingress-host>/actuator/health
+#      # Chat UI + document upload should work with demo-mode auth
+#
+# Binding contract (mounted under /bindings/<name>/)
+# - GenAI: type, config_url, api_key, api_base (optional model / model_capabilities)
+# - Postgres: type=postgresql, uri or host/port/database, username, password
+#
+# Environment fallbacks (Secret cf-mcp-client-k8s-env):
+# - GENAI_CHAT_CONFIG_URL, GENAI_CHAT_API_KEY, GENAI_CHAT_API_BASE
+# - GENAI_EMBEDDING_CONFIG_URL, GENAI_EMBEDDING_API_KEY, GENAI_EMBEDDING_API_BASE
+# - SPRING_DATASOURCE_URL, SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD

--- a/deploy/k8s/00-namespace.yaml
+++ b/deploy/k8s/00-namespace.yaml
@@ -1,0 +1,8 @@
+# Namespace for cf-mcp-client-k8s — align with tanzubotk8s after discovery.
+# Default: demo (same space pattern as tanzubotdemo on CF).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+  labels:
+    app.kubernetes.io/part-of: cf-mcp-client-k8s

--- a/deploy/k8s/10-configmap.yaml
+++ b/deploy/k8s/10-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cf-mcp-client-k8s-config
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: cf-mcp-client-k8s
+data:
+  SPRING_PROFILES_ACTIVE: "k8s"
+  APP_SECURITY_DEMO_MODE: "true"
+  APP_MULTIGENAI_ENABLED: "true"
+  SERVICE_BINDING_ROOT: "/bindings"
+  SERVER_PORT: "8080"

--- a/deploy/k8s/20-deployment.yaml
+++ b/deploy/k8s/20-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cf-mcp-client-k8s
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: cf-mcp-client-k8s
+    app.kubernetes.io/version: "1.6.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cf-mcp-client-k8s
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cf-mcp-client-k8s
+    spec:
+      containers:
+        - name: app
+          image: cf-mcp-client-k8s:1.6.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: cf-mcp-client-k8s-config
+            # Optional secret for GENAI_* / SPRING_DATASOURCE_* when not using ServiceBindings
+            - secretRef:
+                name: cf-mcp-client-k8s-env
+                optional: true
+          volumeMounts:
+            - name: binding-genai-chat
+              mountPath: /bindings/genai-chat
+              readOnly: true
+            - name: binding-genai-embed
+              mountPath: /bindings/genai-embed
+              readOnly: true
+            - name: binding-postgres
+              mountPath: /bindings/postgres-vector
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 40
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: "2"
+              memory: 2Gi
+      volumes:
+        # Prefer ServiceBinding-projected secrets; fall back to manually created secrets.
+        - name: binding-genai-chat
+          secret:
+            secretName: genai-chat-binding
+            optional: true
+        - name: binding-genai-embed
+          secret:
+            secretName: genai-embed-binding
+            optional: true
+        - name: binding-postgres
+          secret:
+            secretName: postgres-vector-binding
+            optional: true

--- a/deploy/k8s/20-deployment.yaml
+++ b/deploy/k8s/20-deployment.yaml
@@ -42,13 +42,13 @@ spec:
               readOnly: true
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/readiness
               port: http
             initialDelaySeconds: 20
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: http
             initialDelaySeconds: 40
             periodSeconds: 20

--- a/deploy/k8s/30-service.yaml
+++ b/deploy/k8s/30-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cf-mcp-client-k8s
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: cf-mcp-client-k8s
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: cf-mcp-client-k8s
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/k8s/40-ingress.yaml
+++ b/deploy/k8s/40-ingress.yaml
@@ -1,0 +1,23 @@
+# Generic Ingress — adjust host/class to match the VKS cluster (same as tanzubotk8s).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cf-mcp-client-k8s
+  namespace: demo
+  labels:
+    app.kubernetes.io/name: cf-mcp-client-k8s
+  annotations:
+    # Contour / nginx / traefik — override after discovering tanzubotk8s ingress class
+    kubernetes.io/ingress.class: contour
+spec:
+  rules:
+    - host: cf-mcp-client-k8s.demo.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cf-mcp-client-k8s
+                port:
+                  name: http

--- a/deploy/k8s/50-servicebindings.yaml
+++ b/deploy/k8s/50-servicebindings.yaml
@@ -1,0 +1,51 @@
+# Example Tanzu / servicebinding.io ServiceBindings.
+# Apply after GenAI and Postgres service instances (or secrets) exist in the namespace.
+# Adjust apiVersion if the cluster uses services.apps.tanzu.vmware.com ResourceClaims instead.
+---
+apiVersion: servicebinding.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: cf-mcp-client-k8s-genai-chat
+  namespace: demo
+spec:
+  service:
+    apiVersion: v1
+    kind: Secret
+    name: genai-chat-binding
+  workload:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cf-mcp-client-k8s
+  name: genai-chat
+---
+apiVersion: servicebinding.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: cf-mcp-client-k8s-genai-embed
+  namespace: demo
+spec:
+  service:
+    apiVersion: v1
+    kind: Secret
+    name: genai-embed-binding
+  workload:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cf-mcp-client-k8s
+  name: genai-embed
+---
+apiVersion: servicebinding.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: cf-mcp-client-k8s-postgres
+  namespace: demo
+spec:
+  service:
+    apiVersion: v1
+    kind: Secret
+    name: postgres-vector-binding
+  workload:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: cf-mcp-client-k8s
+  name: postgres-vector

--- a/deploy/k8s/secrets.example.yaml
+++ b/deploy/k8s/secrets.example.yaml
@@ -1,0 +1,35 @@
+# Template secrets for local/sandbox wiring when Tanzu service instances are not yet claimed.
+# DO NOT commit real credentials. Copy to *-secret.yaml (gitignored) and fill values.
+#
+# kubectl create secret generic genai-chat-binding -n demo \
+#   --from-literal=type=genai \
+#   --from-literal=config_url='https://genai-proxy.../config/v1/endpoint' \
+#   --from-literal=api_key='...' \
+#   --from-literal=api_base='https://genai-proxy.../chat-model'
+#
+# kubectl create secret generic genai-embed-binding -n demo \
+#   --from-literal=type=genai \
+#   --from-literal=model_capabilities=EMBEDDING \
+#   --from-literal=config_url='https://genai-proxy.../config/v1/endpoint' \
+#   --from-literal=api_key='...' \
+#   --from-literal=api_base='https://genai-proxy.../embed-model'
+#
+# kubectl create secret generic postgres-vector-binding -n demo \
+#   --from-literal=type=postgresql \
+#   --from-literal=uri='postgres://user:pass@host:5432/db' \
+#   --from-literal=username='user' \
+#   --from-literal=password='pass' \
+#   --from-literal=host='host' \
+#   --from-literal=port='5432' \
+#   --from-literal=database='db'
+apiVersion: v1
+kind: Secret
+metadata:
+  name: genai-chat-binding
+  namespace: demo
+type: Opaque
+stringData:
+  type: genai
+  config_url: REPLACE_ME
+  api_key: REPLACE_ME
+  api_base: REPLACE_ME

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ applications:
     buildpacks:
       - java_buildpack_offline
     memory: 1G
-    path: target/cf-mcp-client-1.5.4.jar
+    path: target/cf-mcp-client-1.6.0.jar
     instances: 1
     services:
       - sso

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>org.tanzu</groupId>
 	<artifactId>cf-mcp-client</artifactId>
-	<version>1.5.4</version>
+	<version>1.6.0</version>
 	<name>cf-mcp-client</name>
 	<description>Chat Client that can bind to GenAI LLMs, MCP Servers, external memory</description>
 
@@ -105,6 +105,10 @@
 			<version>3.5.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/scripts/deploy-k8s.sh
+++ b/scripts/deploy-k8s.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Deploy cf-mcp-client-k8s to the current kubectl context (homelab VKS).
+# Prerequisites: kubectl context, container image in a pullable registry,
+# binding secrets (or ServiceBindings) for genai-chat, genai-embed, postgres-vector.
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-demo}"
+IMAGE="${IMAGE:?Set IMAGE to registry/cf-mcp-client-k8s:1.6.0}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "==> Discovering sibling tanzubot workloads"
+bash "$ROOT/scripts/discover-tanzubotk8s.sh" || true
+
+echo "==> Applying namespace + config"
+kubectl apply -f "$ROOT/deploy/k8s/00-namespace.yaml"
+kubectl apply -f "$ROOT/deploy/k8s/10-configmap.yaml"
+
+echo "==> Ensuring binding secrets exist (create if missing)"
+for secret in genai-chat-binding genai-embed-binding postgres-vector-binding; do
+  if ! kubectl -n "$NAMESPACE" get secret "$secret" >/dev/null 2>&1; then
+    echo "Missing secret $NAMESPACE/$secret — create from deploy/k8s/secrets.example.yaml"
+    exit 1
+  fi
+done
+
+echo "==> Applying workload"
+sed "s|image: cf-mcp-client-k8s:1.6.0|image: ${IMAGE}|; s|namespace: demo|namespace: ${NAMESPACE}|g" \
+  "$ROOT/deploy/k8s/20-deployment.yaml" | kubectl apply -f -
+sed "s|namespace: demo|namespace: ${NAMESPACE}|g" "$ROOT/deploy/k8s/30-service.yaml" | kubectl apply -f -
+sed "s|namespace: demo|namespace: ${NAMESPACE}|g" "$ROOT/deploy/k8s/40-ingress.yaml" | kubectl apply -f -
+
+kubectl -n "$NAMESPACE" rollout status deploy/cf-mcp-client-k8s --timeout=180s
+kubectl -n "$NAMESPACE" get deploy,svc,ingress,pods -l app.kubernetes.io/name=cf-mcp-client-k8s
+echo "Done. Open the Ingress host and verify chat + /upload."

--- a/scripts/discover-tanzubotk8s.sh
+++ b/scripts/discover-tanzubotk8s.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Discover tanzubotk8s on the current kubectl context and align deploy/k8s manifests.
+set -euo pipefail
+
+echo "Current context: $(kubectl config current-context 2>/dev/null || echo 'NONE')"
+echo "--- Looking for tanzubot / tanzubotk8s / tanzubotdemo ---"
+kubectl get deploy,svc,ingress,httpproxy -A 2>/dev/null | grep -iE 'tanzubot|mcp-client' || true
+echo "--- Namespaces ---"
+kubectl get ns 2>/dev/null || true
+echo "--- Suggest: set NAMESPACE and IMAGE then run deploy/k8s apply ---"

--- a/scripts/publish-k8s-fork.sh
+++ b/scripts/publish-k8s-fork.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Publish the local tree as GitHub repo 0pens0/cf-mcp-client-k8s.
+# Requires a GitHub token that can create repositories under 0pens0.
+set -euo pipefail
+
+OWNER="${OWNER:-0pens0}"
+REPO="${REPO:-cf-mcp-client-k8s}"
+SRC_DIR="${SRC_DIR:-.}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Preparing fork content in $WORK_DIR"
+cp -a "$SRC_DIR"/. "$WORK_DIR"/
+rm -rf "$WORK_DIR"/.git "$WORK_DIR"/target
+cp "$SRC_DIR/README-k8s.md" "$WORK_DIR/README.md"
+
+python3 - <<PY
+from pathlib import Path
+root = Path("$WORK_DIR")
+pom = (root / "pom.xml").read_text()
+pom = pom.replace("<artifactId>cf-mcp-client</artifactId>", "<artifactId>cf-mcp-client-k8s</artifactId>", 1)
+pom = pom.replace("<name>cf-mcp-client</name>", "<name>cf-mcp-client-k8s</name>", 1)
+(root / "pom.xml").write_text(pom)
+df = root / "Dockerfile"
+df.write_text(df.read_text().replace("cf-mcp-client-*.jar", "cf-mcp-client-k8s-*.jar"))
+manifest = root / "manifest.yml"
+if manifest.exists():
+    text = manifest.read_text().replace("cf-mcp-client-sso", "cf-mcp-client-k8s")
+    text = text.replace("cf-mcp-client-1.6.0.jar", "cf-mcp-client-k8s-1.6.0.jar")
+    manifest.write_text(text)
+PY
+
+cd "$WORK_DIR"
+git init -b main
+git add -A
+git -c user.email="${GIT_EMAIL:-cursor@users.noreply.github.com}" \
+    -c user.name="${GIT_NAME:-cursor}" \
+    commit -m "feat: initial cf-mcp-client-k8s fork for VKS/Tanzu Platform"
+
+if gh repo view "$OWNER/$REPO" >/dev/null 2>&1; then
+  echo "Repo $OWNER/$REPO already exists"
+else
+  echo "Creating $OWNER/$REPO"
+  gh repo create "$OWNER/$REPO" --public \
+    --description "Kubernetes/VKS fork of cf-mcp-client-sso for Tanzu Platform (chat + embed + postgres)"
+fi
+
+git remote add origin "https://github.com/$OWNER/$REPO.git"
+git push -u origin main
+echo "Published https://github.com/$OWNER/$REPO"

--- a/src/main/java/org/tanzu/mcpclient/bindings/K8sServiceBindingEnvironmentPostProcessor.java
+++ b/src/main/java/org/tanzu/mcpclient/bindings/K8sServiceBindingEnvironmentPostProcessor.java
@@ -1,0 +1,109 @@
+package org.tanzu.mcpclient.bindings;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Maps Kubernetes service bindings into Spring properties early enough for datasource
+ * availability checks and Spring AI property-based configuration.
+ * <p>
+ * Active when profile {@code k8s} is set, or when {@code SERVICE_BINDING_ROOT} is present.
+ */
+public class K8sServiceBindingEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    private static final Logger logger = LoggerFactory.getLogger(K8sServiceBindingEnvironmentPostProcessor.class);
+    private static final String PROPERTY_SOURCE_NAME = "k8sServiceBindings";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        boolean k8sProfile = environment.acceptsProfiles(org.springframework.core.env.Profiles.of("k8s"));
+        boolean hasBindingRoot = System.getenv(ServiceBindingReader.SERVICE_BINDING_ROOT_PROPERTY) != null
+                || System.getProperty(ServiceBindingReader.SERVICE_BINDING_ROOT_PROPERTY) != null;
+
+        if (!k8sProfile && !hasBindingRoot) {
+            return;
+        }
+
+        Map<String, Object> properties = new HashMap<>();
+
+        Optional<ServiceBindingReader.Binding> postgres = ServiceBindingReader.findFirstPostgres();
+        postgres.ifPresent(binding -> applyPostgres(binding, properties, environment));
+
+        // Prefer explicit GENAI_* env already in the environment; bindings fill gaps for Spring AI props
+        applyGenaiBindingAsSpringAiProps(
+                ServiceBindingReader.findFirstGenaiChat(),
+                "spring.ai.openai.chat",
+                properties,
+                environment);
+        applyGenaiBindingAsSpringAiProps(
+                ServiceBindingReader.findFirstGenaiEmbedding(),
+                "spring.ai.openai.embedding",
+                properties,
+                environment);
+
+        if (!properties.isEmpty()) {
+            environment.getPropertySources().addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+            logger.info("Applied {} properties from Kubernetes service bindings", properties.size());
+        }
+    }
+
+    private void applyPostgres(ServiceBindingReader.Binding binding,
+                               Map<String, Object> properties,
+                               ConfigurableEnvironment environment) {
+        if (environment.containsProperty("spring.datasource.url")
+                && environment.getProperty("spring.datasource.url") != null
+                && !environment.getProperty("spring.datasource.url", "").contains("localhost")) {
+            logger.debug("spring.datasource.url already set; skipping postgres binding override");
+            return;
+        }
+
+        binding.jdbcUrl().ifPresent(url -> {
+            properties.put("spring.datasource.url", url);
+            logger.info("Mapped postgres binding '{}' to spring.datasource.url", binding.name());
+        });
+        binding.username().ifPresent(user -> properties.put("spring.datasource.username", user));
+        binding.password().ifPresent(pass -> properties.put("spring.datasource.password", pass));
+        properties.putIfAbsent("spring.datasource.driver-class-name", "org.postgresql.Driver");
+    }
+
+    private void applyGenaiBindingAsSpringAiProps(Optional<ServiceBindingReader.Binding> bindingOpt,
+                                                  String prefix,
+                                                  Map<String, Object> properties,
+                                                  ConfigurableEnvironment environment) {
+        if (bindingOpt.isEmpty()) {
+            return;
+        }
+        ServiceBindingReader.Binding binding = bindingOpt.get();
+
+        String apiKeyProp = prefix + ".api-key";
+        String baseUrlProp = prefix + ".base-url";
+        String modelProp = prefix + ".options.model";
+
+        if (!environment.containsProperty(apiKeyProp)) {
+            binding.genaiApiKey().ifPresent(key -> properties.put(apiKeyProp, key));
+        }
+        if (!environment.containsProperty(baseUrlProp)) {
+            binding.genaiApiBase().ifPresent(base -> properties.put(baseUrlProp, base));
+        }
+        if (!environment.containsProperty(modelProp)) {
+            String model = binding.getFirst("model", "model_name", "model-name", "modelName");
+            if (model != null) {
+                properties.put(modelProp, model);
+            }
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 20;
+    }
+}

--- a/src/main/java/org/tanzu/mcpclient/bindings/ServiceBindingReader.java
+++ b/src/main/java/org/tanzu/mcpclient/bindings/ServiceBindingReader.java
@@ -1,0 +1,225 @@
+package org.tanzu.mcpclient.bindings;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reads Kubernetes Service Binding directories (SERVICE_BINDING_ROOT, default {@code /bindings}).
+ * Compatible with the Service Binding Specification for Kubernetes and Tanzu Platform bindings.
+ */
+public final class ServiceBindingReader {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServiceBindingReader.class);
+
+    public static final String SERVICE_BINDING_ROOT_PROPERTY = "SERVICE_BINDING_ROOT";
+    public static final String DEFAULT_BINDING_ROOT = "/bindings";
+
+    private ServiceBindingReader() {
+    }
+
+    public static Path bindingRoot() {
+        String root = System.getenv(SERVICE_BINDING_ROOT_PROPERTY);
+        if (root == null || root.isBlank()) {
+            root = System.getProperty(SERVICE_BINDING_ROOT_PROPERTY, DEFAULT_BINDING_ROOT);
+        }
+        return Path.of(root);
+    }
+
+    /**
+     * Returns all binding directories under the binding root that contain a {@code type} file.
+     */
+    public static List<Binding> readAll() {
+        Path root = bindingRoot();
+        if (!Files.isDirectory(root)) {
+            logger.debug("Service binding root {} does not exist or is not a directory", root);
+            return List.of();
+        }
+
+        List<Binding> bindings = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            for (Path entry : stream) {
+                if (!Files.isDirectory(entry)) {
+                    continue;
+                }
+                Map<String, String> entries = readBindingEntries(entry);
+                if (entries.isEmpty()) {
+                    continue;
+                }
+                String type = entries.getOrDefault("type", "");
+                String name = entry.getFileName().toString();
+                bindings.add(new Binding(name, type, entries));
+                logger.info("Discovered service binding name='{}' type='{}' keys={}",
+                        name, type, entries.keySet());
+            }
+        } catch (IOException e) {
+            logger.warn("Failed to read service bindings from {}: {}", root, e.getMessage());
+        }
+        return bindings;
+    }
+
+    public static List<Binding> findByTypeContains(String typeFragment) {
+        String needle = typeFragment.toLowerCase(Locale.ROOT);
+        return readAll().stream()
+                .filter(binding -> binding.type().toLowerCase(Locale.ROOT).contains(needle)
+                        || binding.name().toLowerCase(Locale.ROOT).contains(needle))
+                .toList();
+    }
+
+    public static Optional<Binding> findFirstPostgres() {
+        return readAll().stream()
+                .filter(Binding::isPostgres)
+                .findFirst();
+    }
+
+    public static Optional<Binding> findFirstGenaiChat() {
+        return readAll().stream()
+                .filter(Binding::isGenai)
+                .filter(binding -> !binding.isEmbedding())
+                .findFirst()
+                .or(() -> readAll().stream().filter(Binding::isGenai).findFirst());
+    }
+
+    public static Optional<Binding> findFirstGenaiEmbedding() {
+        return readAll().stream()
+                .filter(Binding::isGenai)
+                .filter(Binding::isEmbedding)
+                .findFirst()
+                .or(() -> readAll().stream()
+                        .filter(binding -> binding.name().toLowerCase(Locale.ROOT).contains("embed"))
+                        .filter(Binding::isGenai)
+                        .findFirst());
+    }
+
+    private static Map<String, String> readBindingEntries(Path bindingDir) throws IOException {
+        Map<String, String> entries = new HashMap<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(bindingDir)) {
+            for (Path file : stream) {
+                if (!Files.isRegularFile(file)) {
+                    continue;
+                }
+                String key = file.getFileName().toString();
+                // Skip metadata-only hidden files commonly present in projected volumes
+                if (key.startsWith(".")) {
+                    continue;
+                }
+                String value = Files.readString(file, StandardCharsets.UTF_8).trim();
+                entries.put(key, value);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Immutable view of a single service binding directory.
+     */
+    public record Binding(String name, String type, Map<String, String> entries) {
+
+        public String get(String key) {
+            return entries.get(key);
+        }
+
+        public String getFirst(String... keys) {
+            for (String key : keys) {
+                String value = entries.get(key);
+                if (value != null && !value.isBlank()) {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        public boolean isPostgres() {
+            String lowerType = type.toLowerCase(Locale.ROOT);
+            String lowerName = name.toLowerCase(Locale.ROOT);
+            return lowerType.contains("postgres")
+                    || lowerType.contains("postgresql")
+                    || lowerName.contains("postgres")
+                    || entries.containsKey("jdbc-url")
+                    || entries.containsKey("jdbcUrl")
+                    || (entries.containsKey("uri") && entries.get("uri").startsWith("postgres"));
+        }
+
+        public boolean isGenai() {
+            String lowerType = type.toLowerCase(Locale.ROOT);
+            String lowerName = name.toLowerCase(Locale.ROOT);
+            return lowerType.contains("genai")
+                    || lowerType.contains("openai")
+                    || lowerName.contains("genai")
+                    || entries.containsKey("config_url")
+                    || entries.containsKey("api_base")
+                    || entries.containsKey("api-base")
+                    || (entries.containsKey("uri") && entries.containsKey("api-key"));
+        }
+
+        public boolean isEmbedding() {
+            String lowerType = type.toLowerCase(Locale.ROOT);
+            String lowerName = name.toLowerCase(Locale.ROOT);
+            String modelCap = Optional.ofNullable(getFirst("model_capabilities", "model-capabilities", "capability"))
+                    .orElse("")
+                    .toLowerCase(Locale.ROOT);
+            return lowerName.contains("embed")
+                    || lowerType.contains("embed")
+                    || modelCap.contains("embed");
+        }
+
+        /**
+         * Builds a JDBC URL from binding fields.
+         */
+        public Optional<String> jdbcUrl() {
+            String explicit = getFirst("jdbc-url", "jdbcUrl", "jdbc_url");
+            if (explicit != null) {
+                return Optional.of(explicit);
+            }
+            String uri = getFirst("uri", "url");
+            if (uri != null && uri.startsWith("jdbc:")) {
+                return Optional.of(uri);
+            }
+            if (uri != null && uri.startsWith("postgres")) {
+                // Convert postgres:// or postgresql:// to jdbc:postgresql://
+                String jdbc = uri.replaceFirst("^postgres(ql)?://", "jdbc:postgresql://");
+                return Optional.of(jdbc);
+            }
+            String host = getFirst("host", "hostname");
+            String port = getFirst("port");
+            String database = getFirst("database", "db", "name");
+            if (host != null && database != null) {
+                String effectivePort = (port == null || port.isBlank()) ? "5432" : port;
+                return Optional.of("jdbc:postgresql://" + host + ":" + effectivePort + "/" + database);
+            }
+            return Optional.empty();
+        }
+
+        public Optional<String> username() {
+            return Optional.ofNullable(getFirst("username", "user", "access-key", "access_key"));
+        }
+
+        public Optional<String> password() {
+            return Optional.ofNullable(getFirst("password", "passwd", "secret", "access-secret", "access_secret"));
+        }
+
+        public Optional<String> genaiConfigUrl() {
+            return Optional.ofNullable(getFirst("config_url", "config-url", "configUrl"));
+        }
+
+        public Optional<String> genaiApiKey() {
+            return Optional.ofNullable(getFirst("api_key", "api-key", "apiKey", "key"));
+        }
+
+        public Optional<String> genaiApiBase() {
+            String base = getFirst("api_base", "api-base", "apiBase", "base_url", "base-url", "baseUrl", "uri", "url");
+            return Optional.ofNullable(base);
+        }
+    }
+}

--- a/src/main/java/org/tanzu/mcpclient/model/MultiGenaiLocatorConfiguration.java
+++ b/src/main/java/org/tanzu/mcpclient/model/MultiGenaiLocatorConfiguration.java
@@ -4,40 +4,107 @@ import io.pivotal.cfenv.boot.genai.DefaultGenaiLocator;
 import io.pivotal.cfenv.boot.genai.GenaiLocator;
 import io.pivotal.cfenv.core.CfEnv;
 import io.pivotal.cfenv.core.CfService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.web.client.RestClient;
+import org.tanzu.mcpclient.bindings.ServiceBindingReader;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
- * Manual configuration for multiple GenaiLocator beans
- * This bypasses the java-cfenv limitation by directly reading VCAP_SERVICES
- * and creating GenaiLocator beans for each GenAI service found.
+ * Creates {@link GenaiLocator} beans from Cloud Foundry VCAP services, Kubernetes
+ * service bindings, and/or explicit {@code GENAI_CHAT_*} / {@code GENAI_EMBEDDING_*}
+ * environment variables.
  */
 @Configuration
 @ConditionalOnProperty(name = "app.multigenai.enabled", havingValue = "true")
 public class MultiGenaiLocatorConfiguration {
 
-    /**
-     * Creates multiple GenaiLocator beans by directly parsing VCAP_SERVICES
-     * This works with your existing MultiGenaiLocatorAggregator
-     */
-    @Bean
-    public List<GenaiLocator> manualGenaiLocators(RestClient.Builder builder) {
-        CfEnv cfEnv = new CfEnv();
+    private static final Logger logger = LoggerFactory.getLogger(MultiGenaiLocatorConfiguration.class);
 
-        return cfEnv.findAllServices().stream()
-                .filter(this::isGenaiService)
-                .map(service -> createGenaiLocator(service, builder))
-                .toList();
+    @Bean
+    public List<GenaiLocator> manualGenaiLocators(RestClient.Builder builder, Environment environment) {
+        List<GenaiLocator> locators = new ArrayList<>();
+
+        locators.addAll(fromVcapServices(builder));
+        locators.addAll(fromServiceBindings(builder));
+        fromEnvVars(builder, environment, "GENAI_CHAT", "chat").ifPresent(locators::add);
+        fromEnvVars(builder, environment, "GENAI_EMBEDDING", "embedding").ifPresent(locators::add);
+
+        logger.info("Configured {} GenaiLocator bean(s) (VCAP + service bindings + env)", locators.size());
+        return locators;
     }
 
-    /**
-     * Checks if a service is a GenAI service
-     */
+    private List<GenaiLocator> fromVcapServices(RestClient.Builder builder) {
+        try {
+            CfEnv cfEnv = new CfEnv();
+            return cfEnv.findAllServices().stream()
+                    .filter(this::isGenaiService)
+                    .map(service -> createGenaiLocator(service, builder))
+                    .toList();
+        } catch (Exception e) {
+            logger.debug("VCAP_SERVICES GenAI discovery skipped: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private List<GenaiLocator> fromServiceBindings(RestClient.Builder builder) {
+        List<GenaiLocator> locators = new ArrayList<>();
+        for (ServiceBindingReader.Binding binding : ServiceBindingReader.readAll()) {
+            if (!binding.isGenai()) {
+                continue;
+            }
+            Optional<String> configUrl = binding.genaiConfigUrl();
+            Optional<String> apiKey = binding.genaiApiKey();
+            Optional<String> apiBase = binding.genaiApiBase();
+
+            if (configUrl.isPresent() && apiKey.isPresent() && apiBase.isPresent()) {
+                logger.info("Creating GenaiLocator from service binding '{}'", binding.name());
+                locators.add(new DefaultGenaiLocator(builder, configUrl.get(), apiKey.get(), apiBase.get()));
+            } else if (apiKey.isPresent() && apiBase.isPresent()) {
+                // OpenAI-compatible binding without GenAI config endpoint: synthesize config URL path
+                String base = trimTrailingSlash(apiBase.get());
+                String synthesizedConfig = base + "/config/v1/endpoint";
+                logger.info("Creating GenaiLocator from service binding '{}' with synthesized config URL",
+                        binding.name());
+                locators.add(new DefaultGenaiLocator(builder, synthesizedConfig, apiKey.get(), base));
+            } else {
+                logger.debug("Skipping GenAI-like binding '{}': missing config_url/api_key/api_base", binding.name());
+            }
+        }
+        return locators;
+    }
+
+    private Optional<GenaiLocator> fromEnvVars(RestClient.Builder builder,
+                                               Environment environment,
+                                               String prefix,
+                                               String label) {
+        String configUrl = firstNonBlank(
+                environment.getProperty(prefix + "_CONFIG_URL"),
+                environment.getProperty(prefix.toLowerCase().replace('_', '.') + ".config-url"));
+        String apiKey = firstNonBlank(
+                environment.getProperty(prefix + "_API_KEY"),
+                environment.getProperty(prefix.toLowerCase().replace('_', '.') + ".api-key"));
+        String apiBase = firstNonBlank(
+                environment.getProperty(prefix + "_API_BASE"),
+                environment.getProperty(prefix.toLowerCase().replace('_', '.') + ".api-base"));
+
+        if (configUrl == null || apiKey == null || apiBase == null) {
+            logger.debug("No complete {} env configuration found for GenaiLocator", prefix);
+            return Optional.empty();
+        }
+
+        logger.info("Creating GenaiLocator from {} environment variables ({})", prefix, label);
+        return Optional.of(new DefaultGenaiLocator(builder, configUrl, apiKey, trimTrailingSlash(apiBase)));
+    }
+
     private boolean isGenaiService(CfService service) {
         boolean hasGenaiTag = service.existsByTagIgnoreCase("genai") ||
                 service.existsByLabelStartsWith("genai");
@@ -45,9 +112,6 @@ public class MultiGenaiLocatorConfiguration {
         return hasGenaiTag && hasEndpoint;
     }
 
-    /**
-     * Creates a GenaiLocator from a CfService
-     */
     private GenaiLocator createGenaiLocator(CfService service, RestClient.Builder builder) {
         Map<String, Object> credentials = service.getCredentials().getMap();
         @SuppressWarnings("unchecked")
@@ -57,19 +121,23 @@ public class MultiGenaiLocatorConfiguration {
         String apiKey = (String) endpoint.get("api_key");
         String apiBase = (String) endpoint.get("api_base");
 
+        logger.info("Creating GenaiLocator from CF service '{}'", service.getName());
         return new DefaultGenaiLocator(builder, configUrl, apiKey, apiBase);
     }
-}
 
-/*
- * If you want to set these manually via environment variables or application.yml:
- *
- * Environment variables example:
- * GENAI_EMBEDDING_CONFIG_URL=https://genai-proxy.sys.tas-ndc.kuhn-labs.com/prod-embedding-nomic-text-97b9b92/config/v1/endpoint
- * GENAI_EMBEDDING_API_KEY=eyJhbGciOiJIUzI1NiJ9...
- * GENAI_EMBEDDING_API_BASE=https://genai-proxy.sys.tas-ndc.kuhn-labs.com/prod-embedding-nomic-text-97b9b92
- *
- * GENAI_CHAT_CONFIG_URL=https://genai-proxy.sys.tas-ndc.kuhn-labs.com/local-mistral-nemo-instruct-2407-5c3c88c/config/v1/endpoint
- * GENAI_CHAT_API_KEY=eyJhbGciOiJIUzI1NiJ9...
- * GENAI_CHAT_API_BASE=https://genai-proxy.sys.tas-ndc.kuhn-labs.com/local-mistral-nemo-instruct-2407-5c3c88c
- */
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String trimTrailingSlash(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+}

--- a/src/main/java/org/tanzu/mcpclient/model/MultiGenaiLocatorConfiguration.java
+++ b/src/main/java/org/tanzu/mcpclient/model/MultiGenaiLocatorConfiguration.java
@@ -29,8 +29,14 @@ public class MultiGenaiLocatorConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(MultiGenaiLocatorConfiguration.class);
 
+    /**
+     * Creates GenaiLocator beans from VCAP, Kubernetes bindings, and GENAI_* env vars.
+     * Uses a standalone {@link RestClient.Builder} (not the Spring-managed bean) to avoid
+     * Actuator ObservationRegistry circular dependencies.
+     */
     @Bean
-    public List<GenaiLocator> manualGenaiLocators(RestClient.Builder builder, Environment environment) {
+    public List<GenaiLocator> manualGenaiLocators(Environment environment) {
+        RestClient.Builder builder = RestClient.builder();
         List<GenaiLocator> locators = new ArrayList<>();
 
         locators.addAll(fromVcapServices(builder));

--- a/src/main/java/org/tanzu/mcpclient/security/K8sSecurityConfig.java
+++ b/src/main/java/org/tanzu/mcpclient/security/K8sSecurityConfig.java
@@ -1,0 +1,63 @@
+package org.tanzu.mcpclient.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Security configuration for the {@code k8s} profile.
+ * <p>
+ * Default {@code app.security.demo-mode=true} permits API use without CF-SSO so chat
+ * and document upload can be exercised on VKS. Set {@code app.security.demo-mode=false}
+ * and configure OAuth2 client registrations to require login.
+ */
+@Configuration
+@EnableWebSecurity
+@Profile("k8s")
+public class K8sSecurityConfig {
+
+    @Value("${app.security.demo-mode:true}")
+    private boolean demoMode;
+
+    @Bean
+    SecurityFilterChain k8sSecurityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable());
+
+        if (demoMode) {
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        } else {
+            http.authorizeHttpRequests(auth -> auth
+                            .requestMatchers(
+                                    "/",
+                                    "/login",
+                                    "/login.html",
+                                    "/static/**",
+                                    "/css/**",
+                                    "/js/**",
+                                    "/images/**",
+                                    "/favicon.ico",
+                                    "/auth/status",
+                                    "/auth/provider",
+                                    "/actuator/health**",
+                                    "/actuator/info",
+                                    "/login**",
+                                    "/oauth2/**",
+                                    "/welcome",
+                                    "/error"
+                            ).permitAll()
+                            .anyRequest().authenticated())
+                    .oauth2Login(oauth -> oauth
+                            .loginPage("/login.html")
+                            .defaultSuccessUrl("/welcome", true))
+                    .logout(l -> l.logoutUrl("/logout").logoutSuccessUrl("/"))
+                    .httpBasic(Customizer.withDefaults());
+        }
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/tanzu/mcpclient/security/SecurityConfig.java
+++ b/src/main/java/org/tanzu/mcpclient/security/SecurityConfig.java
@@ -2,12 +2,14 @@ package org.tanzu.mcpclient.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@Profile("!k8s")
 public class SecurityConfig {
 	
 	@Bean

--- a/src/main/java/org/tanzu/mcpclient/web/LoginController.java
+++ b/src/main/java/org/tanzu/mcpclient/web/LoginController.java
@@ -1,7 +1,9 @@
 package org.tanzu.mcpclient.web;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -13,8 +15,8 @@ import java.util.Map;
 public class LoginController {
 	private final ClientRegistrationRepository clientRegistrationRepository;
 
-	public LoginController(ClientRegistrationRepository clientRegistrationRepository) {
-		this.clientRegistrationRepository = clientRegistrationRepository;
+	public LoginController(ObjectProvider<ClientRegistrationRepository> clientRegistrationRepository) {
+		this.clientRegistrationRepository = clientRegistrationRepository.getIfAvailable();
 	}
 
 	@GetMapping("/login")
@@ -58,14 +60,10 @@ public class LoginController {
 			return null;
 		}
 		try {
-			return ((org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository) clientRegistrationRepository)
+			return ((InMemoryClientRegistrationRepository) clientRegistrationRepository)
 					.findByRegistrationId(id);
 		} catch (ClassCastException e) {
 			return null;
 		}
 	}
 }
-
-
-
-

--- a/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor
@@ -1,0 +1,1 @@
+org.tanzu.mcpclient.bindings.K8sServiceBindingEnvironmentPostProcessor

--- a/src/main/resources/application-k8s.yaml
+++ b/src/main/resources/application-k8s.yaml
@@ -42,8 +42,20 @@ management:
     web:
       exposure:
         include: health,info
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+  health:
+    # Postgres may come up after the pod; liveness should not depend on DB
+    db:
+      enabled: false
+    defaults:
+      enabled: true
 
 logging:
   level:
     org.tanzu.mcpclient: INFO
     org.tanzu.mcpclient.bindings: INFO
+    org.springframework.security: INFO

--- a/src/main/resources/application-k8s.yaml
+++ b/src/main/resources/application-k8s.yaml
@@ -1,0 +1,49 @@
+# Kubernetes / VKS profile for Tanzu Platform service bindings.
+# Activate with: --spring.profiles.active=k8s
+#
+# Expected bindings under SERVICE_BINDING_ROOT (default /bindings):
+#   - Postgres (pgvector): type contains postgres, or jdbc-url / uri / host+database
+#   - GenAI chat + embedding: type/name contains genai, with config_url + api_key + api_base
+#     OR OpenAI-compatible uri + api-key (+ optional model)
+#
+# Alternative env vars (no binding required):
+#   GENAI_CHAT_CONFIG_URL / GENAI_CHAT_API_KEY / GENAI_CHAT_API_BASE
+#   GENAI_EMBEDDING_CONFIG_URL / GENAI_EMBEDDING_API_KEY / GENAI_EMBEDDING_API_BASE
+#   SPRING_DATASOURCE_URL / SPRING_DATASOURCE_USERNAME / SPRING_DATASOURCE_PASSWORD
+
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 50MB
+      max-request-size: 50MB
+  session:
+    # Overridden to jdbc automatically when DatabaseAvailableCondition succeeds
+    store-type: none
+
+app:
+  multigenai:
+    enabled: true
+  security:
+    # When true (default on k8s), APIs are reachable without OAuth so chat/upload
+    # can be demoted without CF-SSO. Set false and provide OIDC client env to enforce login.
+    demo-mode: true
+
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+logging:
+  level:
+    org.tanzu.mcpclient: INFO
+    org.tanzu.mcpclient.bindings: INFO

--- a/src/test/java/org/tanzu/mcpclient/bindings/ServiceBindingReaderTest.java
+++ b/src/test/java/org/tanzu/mcpclient/bindings/ServiceBindingReaderTest.java
@@ -1,0 +1,66 @@
+package org.tanzu.mcpclient.bindings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceBindingReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsPostgresAndGenaiBindings() throws Exception {
+        Path postgres = tempDir.resolve("postgres-vector");
+        Files.createDirectories(postgres);
+        Files.writeString(postgres.resolve("type"), "postgresql");
+        Files.writeString(postgres.resolve("host"), "pg.example");
+        Files.writeString(postgres.resolve("port"), "5432");
+        Files.writeString(postgres.resolve("database"), "vectordb");
+        Files.writeString(postgres.resolve("username"), "pguser");
+        Files.writeString(postgres.resolve("password"), "secret");
+
+        Path chat = tempDir.resolve("genai-chat");
+        Files.createDirectories(chat);
+        Files.writeString(chat.resolve("type"), "genai");
+        Files.writeString(chat.resolve("config_url"), "https://genai.example/chat/config/v1/endpoint");
+        Files.writeString(chat.resolve("api_key"), "chat-key");
+        Files.writeString(chat.resolve("api_base"), "https://genai.example/chat");
+
+        Path embed = tempDir.resolve("genai-embed");
+        Files.createDirectories(embed);
+        Files.writeString(embed.resolve("type"), "genai");
+        Files.writeString(embed.resolve("model_capabilities"), "EMBEDDING");
+        Files.writeString(embed.resolve("config_url"), "https://genai.example/embed/config/v1/endpoint");
+        Files.writeString(embed.resolve("api_key"), "embed-key");
+        Files.writeString(embed.resolve("api_base"), "https://genai.example/embed");
+
+        System.setProperty(ServiceBindingReader.SERVICE_BINDING_ROOT_PROPERTY, tempDir.toString());
+        try {
+            List<ServiceBindingReader.Binding> all = ServiceBindingReader.readAll();
+            assertEquals(3, all.size());
+
+            Optional<ServiceBindingReader.Binding> pg = ServiceBindingReader.findFirstPostgres();
+            assertTrue(pg.isPresent());
+            assertEquals("jdbc:postgresql://pg.example:5432/vectordb", pg.get().jdbcUrl().orElseThrow());
+            assertEquals("pguser", pg.get().username().orElseThrow());
+
+            Optional<ServiceBindingReader.Binding> chatBinding = ServiceBindingReader.findFirstGenaiChat();
+            assertTrue(chatBinding.isPresent());
+            assertEquals("chat-key", chatBinding.get().genaiApiKey().orElseThrow());
+
+            Optional<ServiceBindingReader.Binding> embedBinding = ServiceBindingReader.findFirstGenaiEmbedding();
+            assertTrue(embedBinding.isPresent());
+            assertEquals("embed-key", embedBinding.get().genaiApiKey().orElseThrow());
+        } finally {
+            System.clearProperty(ServiceBindingReader.SERVICE_BINDING_ROOT_PROPERTY);
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a Kubernetes/VKS deployment path so this chat client can run alongside `tanzubotk8s` on the homelab VKS cluster with GenAI chat, GenAI embedding, and Postgres (pgvector) for document upload/RAG.

## Progress
- Version **1.6.0** + k8s bindings/manifests/Dockerfile
- **Image built:** `cf-mcp-client-k8s:1.6.0` (+ artifact tar)
- **Tailscale:** agent node `cursor` online on the homelab tailnet
- **Blocked on Mac SSH:** need agent pubkey in `~/.ssh/authorized_keys` (see `DEPLOYMENT_STATUS.md`)
- Harbor `192.168.82.200` not on advertised Tailscale routes (`10.0.x` only from sparks)

## Next (after Mac authorizes SSH + Harbor route)
1. Discover Tanzu Platform space / `tanzubotk8s`
2. Push image to Harbor
3. Bind GenAI chat + embed + Postgres; deploy; verify chat + upload

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac9b0159-ef03-4bc3-981b-c36f26402671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac9b0159-ef03-4bc3-981b-c36f26402671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

